### PR TITLE
ESI-7097 | Config screen bugfixes

### DIFF
--- a/ui/src/containers/ConfigScreen/index.tsx
+++ b/ui/src/containers/ConfigScreen/index.tsx
@@ -448,6 +448,32 @@ const ConfigScreen: React.FC = function () {
         },
       },
     });
+    if(!Object.keys(state?.installationData?.configuration?.multi_config_keys).length) {
+      {
+        setState({
+          ...state,
+          installationData: {
+            ...state?.installationData,
+            configuration: {
+              ...state?.installationData?.configuration,
+              multi_config_keys: {
+                ...state?.installationData?.configuration?.multi_config_keys,
+                [accordionId]: result?.isMultiConfigAndSaveInConfig,
+              },
+              default_multi_config_key: accordionId,
+            },
+            serverConfiguration: {
+              ...state?.installationData?.serverConfiguration,
+              multi_config_keys: {
+                ...state?.installationData?.serverConfiguration
+                  ?.multi_config_keys,
+                [accordionId]: result?.isMultiConfigAndSaveInServerConfig,
+              },
+            },
+          },
+        });
+      }
+    }
     setState(updateInstallationData);
     state.setInstallationData(updateInstallationData(state));
   };


### PR DESCRIPTION
## Isues fixed in this PR: 

- The first added configuration should be set as the default.
- When adding a second configuration, the save button should be disabled if all mandatory fields are not filled.
- Changing the value of a newly added configuration should not clear the values of previously added configurations.
- A limit on the number of configurations that can be created should be implemented.